### PR TITLE
Update minichecker.js

### DIFF
--- a/Reporting/minichecker.js
+++ b/Reporting/minichecker.js
@@ -182,11 +182,17 @@ function checkWorldwideTargeting(campaignIds) {
             .targeting()
             .targetedLocations()
             .get();
-
         if (!locationIterator.hasNext()) {
-            var issue = {};
-            issue[CAMPAIGN_NAME] = campaign.getName();
-            worldwideTargetingIssues.push(issue);
+            // check if using only radius targeting
+            var proximityIterator = campaign
+                .targeting()
+                .targetedProximities()
+                .get();
+            if (!proximityIterator.hasNext()) {
+                var issue = {};
+                issue[CAMPAIGN_NAME] = campaign.getName();
+                worldwideTargetingIssues.push(issue);
+            }
         }
     }
     return worldwideTargetingIssues;


### PR DESCRIPTION
Adding targeting().targetedProximities for cases when only radius targeting is used on a campaign