### PR TITLE
In market audiences bug fixes

### DIFF
--- a/Bidding/in-market-audiences-bidding.js
+++ b/Bidding/in-market-audiences-bidding.js
@@ -32,7 +32,7 @@ var CAMPAIGN_NAME_DOES_NOT_CONTAIN = [];
 // Leave as [] to include all campaigns.
 var CAMPAIGN_NAME_CONTAINS = [];
 
-var AUDIENCE_MAPPING_CSV_DOWNLOAD_URL = 'https://developers.google.com/adwords/api/docs/appendix/in-market_categories.csv';
+var AUDIENCE_MAPPING_CSV_DOWNLOAD_URL = 'https://developers.google.com/adwords/api/docs/appendix/in-market-categories.tsv';
 
 function main() {
   Logger.log('Getting audience mapping');
@@ -58,7 +58,8 @@ function main() {
 
 function getInMarketAudienceMapping(downloadCsvUrl) {
   var csv = Utilities.parseCsv(
-    UrlFetchApp.fetch(downloadCsvUrl).getContentText()
+    UrlFetchApp.fetch(downloadCsvUrl).getContentText(),
+    '\t'
   );
 
   var headers = csv[0];

--- a/Bidding/in-market-audiences-bidding.js
+++ b/Bidding/in-market-audiences-bidding.js
@@ -241,10 +241,9 @@ function campaignHasAnyCampaignLevelAudiences(campaign) {
 
 function applyBids(operations, audienceMapping) {
   operations.forEach(function (operation) {
-    message = " - Updating " + operation.entityType + ": '" + operation.entityName + "'; "
-    message += "Audience: '" + audienceMapping[operation.audience.getAudienceId()] + "' "
-    message += "New Modifier: " + operation.modifier
-    Logger.log(message);
+    Logger.log(" - Updating " + operation.entityType + ": '" + operation.entityName + "'; ");
+    Logger.log("     - Audience: '" + audienceMapping[operation.audience.getAudienceId()] + "' ");
+    Logger.log("     - New Modifier: " + operation.modifier);
     operation.audience.bidding().setBidModifier(operation.modifier);
   });
 }

--- a/Bidding/in-market-audiences-bidding.js
+++ b/Bidding/in-market-audiences-bidding.js
@@ -211,6 +211,8 @@ function makeOperations(entityCpa, audiences) {
       var audienceCpa = stats.getCost() / stats.getConversions();
       entityCpa = parseFloat(entityCpa);
       var modifier = (entityCpa / audienceCpa);
+      // Google enforces minimum bid of -90% aka *0.1
+      if(modifier < 0.1) modifier = 0.1;
 
       var operation = {};
       operation.audience = audience;


### PR DESCRIPTION
Bugs brought to attention by Jai for iZettle:

 - csv stopped existing, googled and found replacement listed [here](https://developers.google.com/adwords/api/docs/appendix/codes-formats)
 - Modifiers needed to have a minimum of 0.1 (aka -90%) to align with what is allowed by Google
 - Log which campaigns/ad groups are being updated, as the changes logs from Google seem to omit this information 