### PR TITLE
Bug Fix: gmc-disapproval-checker.js

### DIFF
--- a/Monitoring/gmc-disapproval-checker.js
+++ b/Monitoring/gmc-disapproval-checker.js
@@ -69,7 +69,7 @@ function main() {
         product = productStatuses.resources[i];
         if (satisfiesAllFilters(product)) {
           totalProducts += 1;
-          if (product['destinationStatuses'][0]['approvalStatus'] == 'disapproved') {
+          if (product['destinationStatuses'][0]['status'] == 'disapproved') {
             numberDisapprovedProducts++;
           }
         }


### PR DESCRIPTION
The field name for approval status has changed from `approvalStatus` to `status` in the Shopping Content API

Here is an example of a new destination status object:
`{approvedCountries=[GB], destination=Shopping, status=approved}`

This is to fix https://github.com/Brainlabs-Digital/Google-Ads-Scripts/issues/34